### PR TITLE
fix: allow use of the Eloquent Attribute and enum casts

### DIFF
--- a/src/Database/Eloquent/FMModel.php
+++ b/src/Database/Eloquent/FMModel.php
@@ -462,6 +462,8 @@ abstract class FMModel extends Model
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
             return $this->setMutatedAttributeValue($key, $value);
+        } elseif ($this->hasAttributeSetMutator($key)) {
+            return $this->setAttributeMarkedMutatedAttributeValue($key, $value);
         }
 
         // If an attribute is listed as a "date", we'll convert it from a DateTime
@@ -476,6 +478,12 @@ abstract class FMModel extends Model
                 $exploded = explode(' ', $value);
                 $value = $exploded[0];
             }
+        }
+
+        if ($this->isEnumCastable($key)) {
+            $this->setEnumCastableAttribute($key, $value);
+
+            return $this;
         }
 
         if ($this->isClassCastable($key)) {


### PR DESCRIPTION
Adds in the ability to use the Attribute casts from Laravel 8.50 up