### PR TITLE
Use the computed layout name instead of the base layout name

### DIFF
--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -125,7 +125,7 @@ class FileMakerConnection extends Connection
                         case 105:
                             // Layout is missing error
                             // Add the layout name to the message for clarity
-                            $message = $message['message'] . ": " . $this->layout;
+                            $message = $message['message'] . ": " . $this->getLayout();
                             throw new FileMakerDataApiException($message, $code);
                         default:
                             throw new FileMakerDataApiException($message['message'], $code);


### PR DESCRIPTION
When receiving a layout missing message, you would receive an error that the layout was missing exception. In the event that you have a DB_PREFIX set in your config, the exception would be a little ambiguous because the layout you are trying to query and the one being displayed by the exception would not line up. This fixes that by displaying the computed layout name.

Fixes #22 