### PR TITLE
Update where date to allow for different operators

### DIFF
--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -788,9 +788,13 @@ class FMBaseBuilder extends Builder
 
     public function whereDate($column, $operator, $value = null, $boolean = 'and')
     {
+        if (is_null($value)) {
+            $value = $operator;
+            $operator = '=';
+        }
 
-        if ($operator instanceof DateTimeInterface) {
-            $operator = $operator->format('n/j/Y');
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->format('n/j/Y');
         }
 
         return $this->where($column, $operator, $value, $boolean);


### PR DESCRIPTION
The whereDate method of the builder was built to only allow the user to enter the date as the second parameter. However in order to follow along Laravel's conventions we should be able to pass the value in the second parameter or optionally expand it to insert the operator that we want to use as the second parameter and then pass the date as the third parameter. This PR adds this functionality and will default the operator to an = when no operator is passed in.