### PR TITLE
Add eager loading

### DIFF
--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -23,7 +23,15 @@ class FMEloquentBuilder extends Builder
     {
         $records = $this->tobase()->get();
         $models = $this->model->createModelsFromRecordSet($records);
-        return $models;
+
+        // If we actually found models we will also eager load any relationships that
+        // have been specified as needing to be eager loaded, which will solve the
+        // n+1 query issue for the developers to avoid running a lot of queries.
+        if (count($models) > 0) {
+            $models = $this->eagerLoadRelations($models->all());
+        }
+
+        return $this->getModel()->newCollection($models);
     }
 
 

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -29,6 +29,8 @@ class FMEloquentBuilder extends Builder
         // n+1 query issue for the developers to avoid running a lot of queries.
         if (count($models) > 0) {
             $models = $this->eagerLoadRelations($models->all());
+        } else {
+            $models = $models->all();
         }
 
         return $this->getModel()->newCollection($models);

--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -38,4 +38,30 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
 
         $this->query->{$whereIn}($key, $this->getEagerModelKeys($models));
     }
+
+    /**
+     * Gather the keys from an array of related models.
+     *
+     * @param  array  $models
+     * @return array
+     */
+    protected function getEagerModelKeys(array $models)
+    {
+        $keys = [];
+
+        // First we need to gather all of the keys from the parent models so we know what
+        // to query for via the eager loading query. We will add them to an array then
+        // execute a "where in" statement to gather up all of those related records.
+        // Unlike other DB Engines FM does not support nulls and uses an empty string instead.
+        foreach ($models as $model) {
+            $value = $model->{$this->foreignKey};
+            if (! is_null($value) && $value !== '') {
+                $keys[] = $value;
+            }
+        }
+
+        sort($keys);
+
+        return array_values(array_unique($keys));
+    }
 }

--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -20,4 +20,22 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
             $this->query->where($this->ownerKey, '==', $this->child->{$this->foreignKey});
         }
     }
+
+    /**
+     * Set the constraints for an eager load of the relation.
+     *
+     * @param  array  $models
+     * @return void
+     */
+    public function addEagerConstraints(array $models)
+    {
+        // We'll grab the primary key name of the related models since it could be set to
+        // a non-standard name and not "id". We will then construct the constraint for
+        // our eagerly loading query so it returns the proper models from execution.
+        $key = $this->ownerKey;
+
+        $whereIn = $this->whereInMethod($this->related, $this->ownerKey);
+
+        $this->query->{$whereIn}($key, $this->getEagerModelKeys($models));
+    }
 }

--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -52,9 +52,9 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
         // First we need to gather all of the keys from the parent models so we know what
         // to query for via the eager loading query. We will add them to an array then
         // execute a "where in" statement to gather up all of those related records.
-        // Unlike other DB Engines FM does not support nulls and uses an empty string instead.
         foreach ($models as $model) {
             $value = $model->{$this->foreignKey};
+            // Unlike other DB Engines FM does not support nulls and uses an empty string instead.
             if (! is_null($value) && $value !== '') {
                 $keys[] = $value;
             }

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -474,7 +474,9 @@ class FMBaseBuilder extends Builder
             return;
         }
 
-        $this->wheres = Arr::crossJoin($this->wheres, ...$whereIns);
+        $this->wheres = Arr::map(Arr::crossJoin($this->wheres, ...$whereIns), function($conditions) {
+            return array_merge(...array_values($conditions));
+        });
     }
 
     /**

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -542,9 +542,12 @@ class FMBaseBuilder extends Builder
             return;
         }
 
-        $this->wheres = Arr::map(Arr::crossJoin($this->wheres, ...$whereIns), function ($conditions) {
+        $arr = Arr::crossJoin($this->wheres, ...$whereIns);
+        $function = function ($conditions) {
             return array_merge(...array_values($conditions));
-        });
+        };
+
+        $this->wheres = array_map($function, $arr);
     }
 
     /**

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -187,13 +187,13 @@ class FMBaseBuilder extends Builder
     public function delete($id = null): int
     {
         // If an ID is passed to the method we will delete the record with this internal FileMaker record ID
-        if (! is_null($id)) {
+        if (!is_null($id)) {
             $this->where($this->defaultKeyName(), '=', $id);
         }
         $this->applyBeforeQueryCallbacks();
 
         // Check if we have a record ID to delete or if this is a query for a bulk delete
-        if ($this->getRecordId() === null){
+        if ($this->getRecordId() === null) {
             // There's no individual record ID to delete, so do a bulk delete
             return $this->bulkDeleteFromQuery();
         }
@@ -508,24 +508,26 @@ class FMBaseBuilder extends Builder
             'boolean' => $boolean,
             'not' => $not
         ];
+
+        return $this;
     }
 
     protected function computeWhereIns()
     {
         // If no where in clauses return
-        if(empty($this->whereIns)) {
+        if (empty($this->whereIns)) {
             return;
         }
 
-        $whereIns = array_map(function($whereIn) {
+        $whereIns = array_map(function ($whereIn) {
             $finds = [];
 
-            foreach($whereIn['values'] as $value) {
+            foreach ($whereIn['values'] as $value) {
                 $find = [
                     $whereIn['column'] => $value,
                 ];
 
-                if($whereIn['not']) {
+                if ($whereIn['not']) {
                     $find['omit'] = true;
                 }
 
@@ -535,12 +537,12 @@ class FMBaseBuilder extends Builder
             return $finds;
         }, $this->whereIns);
 
-        if(empty($this->wheres)) {
+        if (empty($this->wheres)) {
             $this->wheres = Arr::flatten($whereIns, 1);
             return;
         }
 
-        $this->wheres = Arr::map(Arr::crossJoin($this->wheres, ...$whereIns), function($conditions) {
+        $this->wheres = Arr::map(Arr::crossJoin($this->wheres, ...$whereIns), function ($conditions) {
             return array_merge(...array_values($conditions));
         });
     }

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -607,6 +607,8 @@ class FMBaseBuilder extends Builder
 
         $this->fieldData($values);
 
+        $this->computeWhereIns();
+
         return $this->connection->update($this);
     }
 

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -164,7 +164,7 @@ class FMBaseBuilder extends Builder
         // Create a new find array if null
         $count = sizeof($this->wheres);
         if ($count == 0) {
-            $currentFind = collect([]);
+            $currentFind = [];
         } else {
             $currentFind = $this->wheres[sizeof($this->wheres) - 1];
         }


### PR DESCRIPTION
This PR adds an override to the whereIn method to make it work with FileMaker expected API as well as add the capability to handle eager loading relationships when retrieving models.

Also, because FileMaker does not use null values for empty foreign keys we needed to override a method BelongsTo Relation that gathers the keys for the related models. This method will filter out null and empty strings to prevent a FM Data API Error.

Closes #20.