### PR TITLE
Fix where in not computed on pagination

### DIFF
--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -23,12 +23,12 @@ class FMEloquentBuilder extends Builder
     public function get($columns = ['*'])
     {
         $records = $this->toBase()->get();
-        $models = $this->model->createModelsFromRecordSet(collect($records));
+        $models = $this->model->createModelsFromRecordSet($records);
 
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded, which will solve the
         // n+1 query issue for the developers to avoid running a lot of queries.
-        if (count($models) > 0) {
+        if ($models->isNotEmpty()) {
             $models = $this->eagerLoadRelations($models->all());
         } else {
             $models = $models->all();

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -36,7 +36,6 @@ class FMEloquentBuilder extends Builder
         return $this->getModel()->newCollection($models);
     }
 
-
     /**
      * Set the affected Eloquent model and instance ids.
      *
@@ -72,7 +71,6 @@ class FMEloquentBuilder extends Builder
         return $this->get();
     }
 
-
     /**
      * Determine if any rows exist for the current query.
      * This actually runs the full query, so it doesn't save you any data, just an error capture
@@ -106,7 +104,6 @@ class FMEloquentBuilder extends Builder
         return !$this->exists();
     }
 
-
     /**
      * Add a where clause on the primary key to the query.
      *
@@ -115,7 +112,6 @@ class FMEloquentBuilder extends Builder
      */
     public function whereKeyNot($id)
     {
-
         if (is_array($id) || $id instanceof Arrayable) {
             $this->query->whereNotIn($this->model->getQualifiedKeyName(), $id);
 
@@ -127,15 +123,13 @@ class FMEloquentBuilder extends Builder
         }
 
         // If this is our first where clause we can add the omit directly
-        if (sizeof($this->wheres) === 0){
+        if (count($this->wheres) === 0){
             return $this->where($this->model->getKeyName(), '==', $id)->omit();
         }
 
         // otherwise we need to add a find and omit
         return $this->orWhere($this->model->getKeyName(), '==', $id)->omit();
     }
-
-
 
     public function findByRecordId($recordId)
     {
@@ -144,7 +138,6 @@ class FMEloquentBuilder extends Builder
         $newModel = $this->model::createFromRecord($newRecord);
         return $newModel;
     }
-
 
     /**
      * Get a single column's value from the first result of a query.
@@ -180,16 +173,13 @@ class FMEloquentBuilder extends Builder
         /** @var FMModel $model */
         $model = $this->model;
 
-
         // Map the columns to FileMaker fields and strip out read-only fields/containers
         $fieldsToWrite = $this->model->getAttributesForFileMakerWrite();
-
 
         $modifiedPortals = null;
         foreach($fieldsToWrite as $key => $value) {
             // Check if the field is a portal (it should be an array if it is)
             if (is_array($value)) {
-
                 $modifiedPortals[$key] = $this->getOnlyModifiedPortalFields($fieldsToWrite[$key], $this->model->getOriginal($key));
                 $fieldsToWrite->forget($key);
             }
@@ -219,12 +209,10 @@ class FMEloquentBuilder extends Builder
         /** @var FMModel $model */
         $model = $this->model;
 
-
         // Map the columns to FileMaker fields and strip out read-only fields/containers
         $fieldsToWrite = $this->model->getAttributesForFileMakerWrite();
 
         // we always need to create the record, even if there are no regular or portal fields which have been set
-
         // forward this request to a base query builder to execute the create record request
         $response = $this->query->fieldData($fieldsToWrite->toArray())->portalData($model->portalData)->createRecord();
 
@@ -250,8 +238,7 @@ class FMEloquentBuilder extends Builder
 
     public function duplicate()
     {
-        $response = $this->query->duplicate($this->model->getRecordId());
-        return $response;
+        return $this->query->duplicate($this->model->getRecordId());
     }
 
     /**
@@ -267,7 +254,6 @@ class FMEloquentBuilder extends Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();
@@ -363,6 +349,4 @@ class FMEloquentBuilder extends Builder
 
         return $result;
     }
-
-
 }

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -272,31 +272,6 @@ class FMEloquentBuilder extends Builder
     }
 
     /**
-     *
-     * Retrieve the "count" result of the query.
-     *
-     * @param string $columns
-     * @return int
-     * @throws FileMakerDataApiException
-     */
-    public function count($columns = '*'): int
-    {
-        /** @var FMBaseBuilder $query */
-        $query = $this->query->limit(1);
-        try {
-            $response = $this->getQuery()->getConnection()->performFind($query);
-            $count = $response['response']['dataInfo']['foundCount'];
-        } catch (FileMakerDataApiException $e) {
-            if ($e->getCode() == 401) {
-                $count = 0;
-            } else {
-                throw $e;
-            }
-        }
-        return $count;
-    }
-
-    /**
      * Compares a model's modified portal data and original portal data and returns portal data with only modified fields and recordIds
      *
      * @param $array1 array The modified portal data

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -22,8 +22,8 @@ class FMEloquentBuilder extends Builder
      */
     public function get($columns = ['*'])
     {
-        $records = $this->tobase()->get();
-        $models = $this->model->createModelsFromRecordSet($records);
+        $records = $this->toBase()->get();
+        $models = $this->model->createModelsFromRecordSet(collect($records));
 
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded, which will solve the
@@ -258,7 +258,7 @@ class FMEloquentBuilder extends Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $response = $this->forPage($page, $perPage)->getData();
+        $response = $this->forPage($page, $perPage)->toBase()->getData();
 
         $total = Arr::get($response, 'response.dataInfo.foundCount', 0);
         $results = $this->model->createModelsFromRecordSet(

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -420,7 +420,7 @@ class FMBaseBuilder extends Builder
         return $records;
     }
 
-    protected function getData()
+    public function getData()
     {
         $this->computeWhereIns();
 

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -849,22 +849,9 @@ class FMBaseBuilder extends Builder
      */
     public function count($columns = '*')
     {
-        $this->limit(1);
-        try {
-            $result = $this->connection->performFind($this);
-        } catch (FileMakerDataApiException $e) {
-            if ($e->getCode() === 401) {
-                // no records found - this is ok
-                // return 0
-                return 0;
-            }
+        $response = $this->limit(1)->getData();
 
-            // not a 401, so throw it
-            throw $e;
-        }
-
-        $count = $result['response']['dataInfo']['foundCount'];
-        return (int)$count;
+        return (int)(Arr::get($response, 'response.dataInfo.foundCount', 0));
     }
 
     public function whereDate($column, $operator, $value = null, $boolean = 'and')

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -392,12 +392,14 @@ class FMBaseBuilder extends Builder
     public function scriptPrerequestParam($param): FMBaseBuilder
     {
         $this->scriptPrerequestParam = $param;
+
         return $this;
     }
 
     public function layoutResponse($name): FMBaseBuilder
     {
         $this->layoutResponse = $name;
+
         return $this;
     }
 

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -410,7 +410,7 @@ class FMBaseBuilder extends Builder
      */
     public function get($columns = ['*'])
     {
-        $records = Arr::get($this->getData(), 'response.data', []);
+        $records = collect(Arr::get($this->getData(), 'response.data', []));
 
         // filter to only requested columns
         if ($columns !== ['*']) {
@@ -583,6 +583,7 @@ class FMBaseBuilder extends Builder
         $this->orderBy($column, $direction);
         $result = $this->first();
         $min = $result['fieldData'][$this->getMappedFieldName($column)];
+
         return $min;
     }
 


### PR DESCRIPTION
This PR includes the following updates:

- Separated repeated logic in several methods, including get, paginate, count, etc, into a new method named `getData`
- Implemented paginate method on the base builder. Previously, this was being handled by Laravel's default query builder.
- Switching to the consolidated `getData` method also allowed us to make sure other methods needing to make get style queries will compute any `whereIn` clauses before making the call to FileMaker - Closes #31
- Minor code style cleanup