### PR TITLE
change RetryMiddleware param to TransferException

### DIFF
--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -10,7 +10,7 @@ use BlueFeather\EloquentFileMaker\Database\Query\Grammars\FMGrammar;
 use BlueFeather\EloquentFileMaker\Database\Schema\FMBuilder;
 use BlueFeather\EloquentFileMaker\Exceptions\FileMakerDataApiException;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Middleware;
 use Illuminate\Database\Connection;
 use Illuminate\Http\Client\PendingRequest;
@@ -664,7 +664,7 @@ class FileMakerConnection extends Connection
             $retries,
             RequestInterface $request,
             ResponseInterface $response = null,
-            RequestException $exception = null
+            TransferException $exception = null
         ) {
             // Limit the number of retries to 5
             if ($retries >= $this->retries) {


### PR DESCRIPTION
Hi,

when an ConnectException occures the RetryMiddleware throws an invalid argument exception.

This PR should fix this issue.

```TypeError: BlueFeather\EloquentFileMaker\Services\FileMakerConnection::BlueFeather\EloquentFileMaker\Services\{closure}(): Argument #4 ($exception) must be of type ?GuzzleHttp\Exception\RequestException, GuzzleHttp\Exception\ConnectException given, called in /var/www/html/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php on line 99 and defined in /var/www/html/vendor/bluefeather/eloquent-filemaker/src/Services/FileMakerConnection.php:663
Stack trace:
#0 /var/www/html/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php(99): BlueFeather\EloquentFileMaker\Services\FileMakerConnection->BlueFeather\EloquentFileMaker\Services\{closure}()
#1 /var/www/html/vendor/guzzlehttp/promises/src/RejectedPromise.php(42): GuzzleHttp\RetryMiddleware->GuzzleHttp\{closure}()
#2 /var/www/html/vendor/guzzlehttp/promises/src/TaskQueue.php(48): GuzzleHttp\Promise\RejectedPromise::GuzzleHttp\Promise\{closure}()
#3 /var/www/html/vendor/guzzlehttp/promises/src/Promise.php(248): GuzzleHttp\Promise\TaskQueue->run()
#4 /var/www/html/vendor/guzzlehttp/promises/src/Promise.php(224): GuzzleHttp\Promise\Promise->invokeWaitFn()
#5 /var/www/html/vendor/guzzlehttp/promises/src/Promise.php(269): GuzzleHttp\Promise\Promise->waitIfPending()
#6 /var/www/html/vendor/guzzlehttp/promises/src/Promise.php(226): GuzzleHttp\Promise\Promise->invokeWaitList()
#7 /var/www/html/vendor/guzzlehttp/promises/src/Promise.php(62): GuzzleHttp\Promise\Promise->waitIfPending()
#8 /var/www/html/vendor/guzzlehttp/guzzle/src/Client.php(187): GuzzleHttp\Promise\Promise->wait()
#9 /var/www/html/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php(962): GuzzleHttp\Client->request()
#10 /var/www/html/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php(823): Illuminate\Http\Client\PendingRequest->sendRequest()
#11 /var/www/html/vendor/laravel/framework/src/Illuminate/Support/helpers.php(247): Illuminate\Http\Client\PendingRequest->Illuminate\Http\Client\{closure}()
#12 /var/www/html/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php(863): retry()
#13 /var/www/html/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php(728): Illuminate\Http\Client\PendingRequest->send()
#14 /var/www/html/vendor/bluefeather/eloquent-filemaker/src/Services/FileMakerConnection.php(644): Illuminate\Http\Client\PendingRequest->post()
#15 /var/www/html/vendor/bluefeather/eloquent-filemaker/src/Services/FileMakerConnection.php(236): BlueFeather\EloquentFileMaker\Services\FileMakerConnection->makeRequest()
#16 /var/www/html/vendor/bluefeather/eloquent-filemaker/src/Database/Query/FMBaseBuilder.php(429): BlueFeather\EloquentFileMaker\Services\FileMakerConnection->performFind()
#17 /var/www/html/vendor/bluefeather/eloquent-filemaker/src/Database/Query/FMBaseBuilder.php(413): BlueFeather\EloquentFileMaker\Database\Query\FMBaseBuilder->getData()
#18 /var/www/html/vendor/bluefeather/eloquent-filemaker/src/Database/Eloquent/FMEloquentBuilder.php(25): BlueFeather\EloquentFileMaker\Database\Query\FMBaseBuilder->get()
#19 /var/www/html/modules/FMSync/Jobs/SyncFmRecords.php(64): BlueFeather\EloquentFileMaker\Database\Eloquent\FMEloquentBuilder->get()
#20 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): Modules\FMSync\Jobs\SyncFmRecords->handle()
#21 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Util.php(41): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#22 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\Util::unwrapIfClosure()
#23 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\Container\BoundMethod::callBoundMethod()
#24 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Container.php(661): Illuminate\Container\BoundMethod::call()
#25 /var/www/html/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(128): Illuminate\Container\Container->call()
#26 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(141): Illuminate\Bus\Dispatcher->Illuminate\Bus\{closure}()
#27 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(116): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#28 /var/www/html/vendor/laravel/framework/src/Illuminate/Bus/Dispatcher.php(132): Illuminate\Pipeline\Pipeline->then()
#29 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(124): Illuminate\Bus\Dispatcher->dispatchNow()
#30 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(141): Illuminate\Queue\CallQueuedHandler->Illuminate\Queue\{closure}()
#31 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(116): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#32 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(126): Illuminate\Pipeline\Pipeline->then()
#33 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(70): Illuminate\Queue\CallQueuedHandler->dispatchThroughMiddleware()
#34 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php(98): Illuminate\Queue\CallQueuedHandler->call()
#35 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/Worker.php(425): Illuminate\Queue\Jobs\Job->fire()
#36 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/Worker.php(375): Illuminate\Queue\Worker->process()
#37 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/Worker.php(173): Illuminate\Queue\Worker->runJob()
#38 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php(147): Illuminate\Queue\Worker->daemon()
#39 /var/www/html/vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php(130): Illuminate\Queue\Console\WorkCommand->runWorker()
#40 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): Illuminate\Queue\Console\WorkCommand->handle()
#41 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Util.php(41): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#42 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\Util::unwrapIfClosure()
#43 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\Container\BoundMethod::callBoundMethod()
#44 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Container.php(661): Illuminate\Container\BoundMethod::call()
#45 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Command.php(183): Illuminate\Container\Container->call()
#46 /var/www/html/vendor/symfony/console/Command/Command.php(312): Illuminate\Console\Command->execute()
#47 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Command.php(153): Symfony\Component\Console\Command\Command->run()
#48 /var/www/html/vendor/symfony/console/Application.php(1022): Illuminate\Console\Command->run()
#49 /var/www/html/vendor/symfony/console/Application.php(314): Symfony\Component\Console\Application->doRunCommand()
#50 /var/www/html/vendor/symfony/console/Application.php(168): Symfony\Component\Console\Application->doRun()
#51 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Application.php(102): Symfony\Component\Console\Application->run()
#52 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(155): Illuminate\Console\Application->run()
#53 /var/www/html/artisan(37): Illuminate\Foundation\Console\Kernel->handle()
#54 {main}```