### PR TITLE
Add vendor publish as well as register make:fm-model command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ php artisan vendor:publish --tag=eloquent-filemaker-override-model
 This publish will create a `model.stub` that will be used by `php artisan make:model` to set up new models. You should use this on projects that will only have models backed by FileMaker.
 
 ## Alternatively, use new make command
-Alternatively, you can use the new `make:fm-model` command. All options available to Laravel's native `make:model` command are also available to `make:fm-model` command. 
+Alternatively, you can use the default `make:model` command with a new `--filemaker` flag. All options available to Laravel's native `make:model` command are still available for use. 
 
 ```shell
-php artisan make:fm-model Model
+php artisan make:model Model --filemaker
 ```
+
+Note: If the `--filemaker` flag is not used, the model will be created as a standard Laravel model.
 
 # Usage
 With the package installed you can now have access to all the features of this package. There are a few different areas to configure.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ Install `gearbox-solutions/eloquent-filemaker` in your project using Composer.
 ```
 composer require gearbox-solutions/eloquent-filemaker
 ```
+
+## Vendor Publish
+This package adds 2 optional vendor publishes that will create a model stub for you that you can customize.
+```shell
+php artisan vendor:publish --tag=eloquent-filemaker-stubs 
+// or 
+php artisan vendor:publish --provider="GearboxSolutions\EloquentFileMaker\Providers\FileMakerConnectionServiceProvider"
+```
+This publish is best if you are looking to have a mix of FileMaker backed models and another DB backed model.
+
+```shell
+php artisan vendor:publish --tag=eloquent-filemaker-override-model
+```
+This publish will create a `model.stub` that will be used by `php artisan make:model` to set up new models. You should use this on projects that will only have models backed by FileMaker.
+
+## Alternatively, use new make command
+Alternatively, you can use the new `make:fm-model` command. All options available to Laravel's native `make:model` command are also available to `make:fm-model` command. 
+
+```shell
+php artisan make:fm-model Model
+```
+
 # Usage
 With the package installed you can now have access to all the features of this package. There are a few different areas to configure.
 

--- a/README.md
+++ b/README.md
@@ -60,20 +60,6 @@ Install `gearbox-solutions/eloquent-filemaker` in your project using Composer.
 composer require gearbox-solutions/eloquent-filemaker
 ```
 
-## Vendor Publish
-This package adds 2 optional vendor publishes that will create a model stub for you that you can customize.
-```shell
-php artisan vendor:publish --tag=eloquent-filemaker-stubs 
-// or 
-php artisan vendor:publish --provider="GearboxSolutions\EloquentFileMaker\Providers\FileMakerConnectionServiceProvider"
-```
-This publish is best if you are looking to have a mix of FileMaker backed models and another DB backed model.
-
-```shell
-php artisan vendor:publish --tag=eloquent-filemaker-override-model
-```
-This publish will create a `model.stub` that will be used by `php artisan make:model` to set up new models. You should use this on projects that will only have models backed by FileMaker.
-
 # Usage
 With the package installed you can now have access to all the features of this package. There are a few different areas to configure.
 
@@ -133,7 +119,29 @@ You can use the default `php artisan make:model` command with a new `--filemaker
 php artisan make:model MyNewModel --filemaker
 ```
 
-#### Things that work
+### Set FMModel as default with a model stub
+
+If you would like all of your models to be published as FMModel by default so that you don't have to use `--filemaker` in your commands, you can use the following command to publish a model stub that will be used by `php artisan make:model` to set up new models.
+
+```shell
+php artisan vendor:publish --tag=eloquent-filemaker-override-model
+```
+This publish will create a `/stubs/model.stub` that will be used by `php artisan make:model` to set up new models. You should use this on projects that will only have models backed by FileMaker.
+
+If you want to customize the model stub ONLY for when the `---filemaker` flag is used, you can do so with the following command:
+
+```shell
+php artisan vendor:publish --tag=eloquent-filemaker-stubs 
+````
+ or
+```shell
+php artisan vendor:publish --provider="GearboxSolutions\EloquentFileMaker\Providers\FileMakerConnectionServiceProvider"
+```
+This stub publish option is best if you are looking to have a mix of FileMaker backed models and another DB backed model.
+
+
+
+### Things that work
 
 The FMModel class extends the base Laravel Model class, and can be used very similarly. It supports many standard Eloquent query builder features for working with data, such as where(), find(), id(), orderBy(), delete(), save(), and many more!
 
@@ -143,7 +151,7 @@ Our goal is to be able to use any of these Eloquent features which make sense, s
 
 Be sure to read [Laravel's Eloquent Documentation](https://laravel.com/docs/8.x/eloquent) to see all the things the Eloquent Model class can do.
 
-#### Things that don't work
+### Things that don't work
 Because this class extends Model, all of the regular eloquent methods may show as available in your IDE, but some don't make sense in the context of FileMaker's Data API and therefore don't do anything. Some examples of this would be mass updates or raw SQL queries.
 
 ### Setting a layout

--- a/README.md
+++ b/README.md
@@ -74,15 +74,6 @@ php artisan vendor:publish --tag=eloquent-filemaker-override-model
 ```
 This publish will create a `model.stub` that will be used by `php artisan make:model` to set up new models. You should use this on projects that will only have models backed by FileMaker.
 
-## Alternatively, use new make command
-Alternatively, you can use the default `make:model` command with a new `--filemaker` flag. All options available to Laravel's native `make:model` command are still available for use. 
-
-```shell
-php artisan make:model Model --filemaker
-```
-
-Note: If the `--filemaker` flag is not used, the model will be created as a standard Laravel model.
-
 # Usage
 With the package installed you can now have access to all the features of this package. There are a few different areas to configure.
 
@@ -135,7 +126,12 @@ cache_driver=file
 ## Model Classes
 Creating model classes is the easiest way to access your FileMaker data, and is the most Laravel-like way of doing things. Create a new model class and change the extension class from `Model` to `FMModel`. This class change enables you to use the features of this package with your models.
 
+### Artisan make:model command
+You can use the default `php artisan make:model` command with a new `--filemaker` flag to make a new `FMModel` instead of the default `Model`. All options available to Laravel's native `make:model` command are still available for use.
 
+```shell
+php artisan make:model MyNewModel --filemaker
+```
 
 #### Things that work
 

--- a/src/Commands/FMModelMakeCommand.php
+++ b/src/Commands/FMModelMakeCommand.php
@@ -6,8 +6,8 @@ use Illuminate\Foundation\Console\ModelMakeCommand as LaravelModelMakeCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
-class FMModelMakeCommand extends LaravelModelMakeCommand {
-
+class FMModelMakeCommand extends LaravelModelMakeCommand
+{
     protected $name = 'make:fm-model';
 
     /**
@@ -28,10 +28,10 @@ class FMModelMakeCommand extends LaravelModelMakeCommand {
     {
         $stub = parent::getStub();
 
-        if($this->option('filemaker')) {
+        if ($this->option('filemaker')) {
             $stub = Str::replace('/model.', '/fm.model.', $stub);
 
-            throw_if(!file_exists($stub), new \RuntimeException("This model type is not yet supported by Eloquent FileMaker."));
+            throw_if(! file_exists($stub), new \RuntimeException('This model type is not yet supported by Eloquent FileMaker.'));
         }
 
         return $stub;

--- a/src/Commands/FMModelMakeCommand.php
+++ b/src/Commands/FMModelMakeCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace GearboxSolutions\EloquentFileMaker\Commands;
+
+use Illuminate\Foundation\Console\ModelMakeCommand as LaravelModelMakeCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+
+class FMModelMakeCommand extends LaravelModelMakeCommand {
+
+    protected $name = 'make:fm-model';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Eloquent FileMaker model class';
+
+    public function handle()
+    {
+        parent::handle();
+
+        $this->input->setOption('filemaker', true);
+    }
+
+    public function getStub()
+    {
+        $stub = parent::getStub();
+
+        if($this->option('filemaker')) {
+            $stub = Str::replace('/model.', '/fm.model.', $stub);
+
+            throw_if(!file_exists($stub), new \RuntimeException("This model type is not yet supported by Eloquent FileMaker."));
+        }
+
+        return $stub;
+    }
+
+    protected function getOptions()
+    {
+        return array_merge(parent::getOptions(), [
+            ['filemaker', null, InputOption::VALUE_NONE, 'Use the FileMaker stub instead of base model stub'],
+        ]);
+    }
+}

--- a/src/Commands/FMModelMakeCommand.php
+++ b/src/Commands/FMModelMakeCommand.php
@@ -3,7 +3,6 @@
 namespace GearboxSolutions\EloquentFileMaker\Commands;
 
 use Illuminate\Foundation\Console\ModelMakeCommand as LaravelModelMakeCommand;
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
 class FMModelMakeCommand extends LaravelModelMakeCommand
@@ -29,12 +28,27 @@ class FMModelMakeCommand extends LaravelModelMakeCommand
         $stub = parent::getStub();
 
         if ($this->option('filemaker')) {
-            $stub = Str::replace('/model.', '/fm.model.', $stub);
+            if ($this->option('pivot') || $this->option('morph-pivot')) {
+                throw new \RuntimeException('This model type is not yet supported by Eloquent FileMaker.');
+            }
 
-            throw_if(! file_exists($stub), new \RuntimeException('This model type is not yet supported by Eloquent FileMaker.'));
+            $stub = $this->resolveStubPath('/stubs/fm.model.stub');
         }
 
         return $stub;
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__ . $stub;
     }
 
     protected function getOptions()

--- a/src/Commands/FMModelMakeCommand.php
+++ b/src/Commands/FMModelMakeCommand.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class FMModelMakeCommand extends LaravelModelMakeCommand
 {
-    protected $name = 'make:fm-model';
+    protected $name = 'make:model';
 
     /**
      * The console command description.
@@ -32,7 +32,7 @@ class FMModelMakeCommand extends LaravelModelMakeCommand
                 throw new \RuntimeException('This model type is not yet supported by Eloquent FileMaker.');
             }
 
-            $stub = $this->resolveStubPath('/stubs/fm.model.stub');
+            $stub = $this->resolveFMStubPath('/stubs/fm.model.stub');
         }
 
         return $stub;
@@ -44,7 +44,7 @@ class FMModelMakeCommand extends LaravelModelMakeCommand
      * @param  string  $stub
      * @return string
      */
-    protected function resolveStubPath($stub)
+    protected function resolveFMStubPath($stub)
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath

--- a/src/Commands/stubs/fm.model.stub
+++ b/src/Commands/stubs/fm.model.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use GearboxSolutions\EloquentFileMaker\Database\Eloquent\FMModel;
+
+class {{ class }} extends FMModel
+{
+    use HasFactory;
+}

--- a/src/Providers/FileMakerConnectionServiceProvider.php
+++ b/src/Providers/FileMakerConnectionServiceProvider.php
@@ -2,11 +2,10 @@
 
 namespace GearboxSolutions\EloquentFileMaker\Providers;
 
-use GearboxSolutions\EloquentFileMaker\Middleware\EndSession;
 use GearboxSolutions\EloquentFileMaker\Commands\FMModelMakeCommand;
+use GearboxSolutions\EloquentFileMaker\Middleware\EndSession;
 use GearboxSolutions\EloquentFileMaker\Services\FileMakerConnection;
 use Illuminate\Contracts\Http\Kernel;
-use Illuminate\Foundation\Console\ModelMakeCommand as LaravelModelMakeCommand;
 use Illuminate\Support\ServiceProvider;
 
 class FileMakerConnectionServiceProvider extends ServiceProvider

--- a/src/Providers/FileMakerConnectionServiceProvider.php
+++ b/src/Providers/FileMakerConnectionServiceProvider.php
@@ -61,11 +61,11 @@ class FileMakerConnectionServiceProvider extends ServiceProvider
             __DIR__ . '/../config/eloquent-filemaker.php' => config_path('eloquent-filemaker.php'),
         ], 'eloquent-filemaker-config');
         $this->publishes([
-            __DIR__.'/../Commands/stubs/fm.model.stub' => base_path('stubs/model.stub')
+            __DIR__ . '/../Commands/stubs/fm.model.stub' => base_path('stubs/model.stub'),
         ], 'eloquent-filemaker-override-model');
 
         $this->publishes([
-            __DIR__.'/../Commands/stubs/fm.model.stub' => base_path('stubs/fm.model.stub')
+            __DIR__ . '/../Commands/stubs/fm.model.stub' => base_path('stubs/fm.model.stub'),
         ], 'eloquent-filemaker-stubs');
     }
 }

--- a/src/Providers/FileMakerConnectionServiceProvider.php
+++ b/src/Providers/FileMakerConnectionServiceProvider.php
@@ -3,8 +3,10 @@
 namespace GearboxSolutions\EloquentFileMaker\Providers;
 
 use GearboxSolutions\EloquentFileMaker\Middleware\EndSession;
+use GearboxSolutions\EloquentFileMaker\Commands\FMModelMakeCommand;
 use GearboxSolutions\EloquentFileMaker\Services\FileMakerConnection;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Foundation\Console\ModelMakeCommand as LaravelModelMakeCommand;
 use Illuminate\Support\ServiceProvider;
 
 class FileMakerConnectionServiceProvider extends ServiceProvider
@@ -38,6 +40,11 @@ class FileMakerConnectionServiceProvider extends ServiceProvider
 
         app('router')->aliasMiddleware('fm.end-session', EndSession::class);
 
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                FMModelMakeCommand::class,
+            ]);
+        }
     }
 
     /**
@@ -49,5 +56,16 @@ class FileMakerConnectionServiceProvider extends ServiceProvider
     {
         // add the middleware to the global middleware so that we always end the FileMaker session
         $kernel->pushMiddleware(EndSession::class);
+
+        $this->publishes([
+            __DIR__ . '/../config/eloquent-filemaker.php' => config_path('eloquent-filemaker.php'),
+        ], 'eloquent-filemaker-config');
+        $this->publishes([
+            __DIR__.'/../Commands/stubs/fm.model.stub' => base_path('stubs/model.stub')
+        ], 'eloquent-filemaker-override-model');
+
+        $this->publishes([
+            __DIR__.'/../Commands/stubs/fm.model.stub' => base_path('stubs/fm.model.stub')
+        ], 'eloquent-filemaker-stubs');
     }
 }


### PR DESCRIPTION
This PR creates 2 option vendor:publish options. The default will publish a new model in the stubs folder that will be used by the make:fm-model command. The second option will publish the fm.model to override the default model.stub so you can use `make:model` intended if you plan to only use this project with FileMaker backed models. Also, created a new command `make:fm-model` that will create model similar to Laravel's native `make:model` command. The readme file has been updated to include these new features.