### PR TITLE
Fix logic of where method to work with whereNot

### DIFF
--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -74,6 +74,7 @@ class FMEloquentBuilder extends Builder
                 throw $e;
             }
         }
+
         // It didn't error, so we have something
         return true;
     }
@@ -263,8 +264,8 @@ class FMEloquentBuilder extends Builder
     /**
      * Compares a model's modified portal data and original portal data and returns portal data with only modified fields and recordIds
      *
-     * @param $array1 array The modified portal data
-     * @param $array2 array The model's original portal data
+     * @param  $array1  array The modified portal data
+     * @param  $array2  array The model's original portal data
      */
     protected function getOnlyModifiedPortalFields($array1, $array2): array
     {

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -342,7 +342,7 @@ class FMEloquentBuilder extends Builder
             $result = $scope(...$parameters) ?? $this;
         }
 
-        $query->unsetFindRequestIndex();
+        $query->resetFindRequestIndex();
 
         return $result;
     }

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -290,6 +290,23 @@ class FMEloquentBuilder extends Builder
         return $result;
     }
 
+    public function applyScopes()
+    {
+        $builder = parent::applyScopes();
+
+        $query = $builder->getQuery();
+
+        foreach ($query->wheres as $index => $find) {
+            if (! empty($find)) {
+                continue;
+            }
+
+            unset($query->wheres[$index]);
+        }
+
+        return $builder;
+    }
+
     /**
      * Apply the given scope on the current builder instance.
      *

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -7,6 +7,7 @@ use GearboxSolutions\EloquentFileMaker\Database\Query\FMBaseBuilder;
 use GearboxSolutions\EloquentFileMaker\Exceptions\FileMakerDataApiException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -285,6 +286,46 @@ class FMEloquentBuilder extends Builder
                 // The values are equal
             }
         }
+
+        return $result;
+    }
+
+    /**
+     * Apply the given scope on the current builder instance.
+     *
+     * @return mixed
+     */
+    protected function callScope(callable $scope, array $parameters = [])
+    {
+        array_unshift($parameters, $this);
+
+        $query = $this->getQuery();
+
+        $result = $this;
+
+        $scopeApplied = false;
+
+        foreach ($query->wheres as $index => $find) {
+            if (($find['omit'] ?? 'false') === 'true') {
+                continue;
+            }
+
+            $query->setFindRequestIndex($index);
+
+            $result = $scope(...$parameters) ?? $this;
+
+            $scopeApplied = true;
+        }
+
+        if (! $scopeApplied) {
+            array_unshift($query->wheres, []);
+
+            $query->setFindRequestIndex(0);
+
+            $result = $scope(...$parameters) ?? $this;
+        }
+
+        $query->unsetFindRequestIndex();
 
         return $result;
     }

--- a/src/Database/Eloquent/FMModel.php
+++ b/src/Database/Eloquent/FMModel.php
@@ -18,9 +18,9 @@ use Illuminate\Support\Str;
 
 abstract class FMModel extends Model
 {
+    use FMGuardsAttributes;
     use FMHasAttributes;
     use FMHasRelationships;
-    use FMGuardsAttributes;
 
     /**
      * Indicates if the model should be timestamped.

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -159,9 +159,9 @@ class FMBaseBuilder extends Builder
         if ($boolean === 'or' || $shouldBeOmit) {
             $this->addFindRequest();
 
-        if ($shouldBeOmit) {
-            $this->omit();
-        }
+            if ($shouldBeOmit) {
+                $this->omit();
+            }
         }
 
         // If the column is an array, we will assume it is an array of key-value pairs

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -180,9 +180,9 @@ class FMBaseBuilder extends Builder
             $this->addFindRequest();
         }
 
-            if ($shouldBeOmit) {
-                $this->omit();
-            }
+        if ($shouldBeOmit) {
+            $this->omit();
+        }
 
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -256,6 +256,7 @@ class FMBaseBuilder extends Builder
                 throw $e;
             }
         }
+
         // we deleted the record, return modified count of 1
         return 1;
     }
@@ -285,6 +286,7 @@ class FMBaseBuilder extends Builder
                 }
             }
         }
+
         // Return the count of deleted records
         return $deleteCount;
     }
@@ -309,6 +311,7 @@ class FMBaseBuilder extends Builder
                 throw $e;
             }
         }
+
         // we deleted the record, return modified count of 1
         return 1;
     }
@@ -441,7 +444,7 @@ class FMBaseBuilder extends Builder
         return $this;
     }
 
-    public function scriptPrerequest(string $scriptName, string $param = null): FMBaseBuilder
+    public function scriptPrerequest(string $scriptName, ?string $param = null): FMBaseBuilder
     {
         $this->scriptPrerequest = $scriptName;
 
@@ -527,7 +530,7 @@ class FMBaseBuilder extends Builder
     /**
      * A helper function to map an entire array of fields and data to their FileMaker field names
      *
-     * @param $array array An array of columns and their values
+     * @param  $array  array An array of columns and their values
      */
     protected function mapFieldNamesForArray(array $array): array
     {
@@ -772,7 +775,7 @@ class FMBaseBuilder extends Builder
     /**
      * Set the field data to be used when creating or editing a record
      *
-     * @param $array array
+     * @param  $array  array
      * @return $this
      */
     public function fieldData(array $array)
@@ -785,7 +788,7 @@ class FMBaseBuilder extends Builder
     /**
      * Set the portal data to be used when creating or updating a record
      *
-     * @param $array array
+     * @param  $array  array
      * @return $this
      */
     public function portalData(array $array)
@@ -796,8 +799,8 @@ class FMBaseBuilder extends Builder
     }
 
     /**
-     * @param  string  $column The name of the container field
-     * @param  File | UploadedFile | array  $file The file to be uploaded to the container or a file and filename array ex: [$file, 'MyFile.pdf']
+     * @param  string  $column  The name of the container field
+     * @param  File | UploadedFile | array  $file  The file to be uploaded to the container or a file and filename array ex: [$file, 'MyFile.pdf']
      * @return mixed
      */
     public function setContainer($column, $file)

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -11,6 +11,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class FMBaseBuilder extends Builder
@@ -145,10 +146,22 @@ class FMBaseBuilder extends Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and'): FMBaseBuilder
     {
+        $shouldBeOmit = false;
+
+        if (Str::contains($boolean, 'not')) {
+            $shouldBeOmit = true;
+            $boolean = trim(str_replace('not', '', $boolean));
+        }
+
         // This is an "orWhere" type query, so add a find request and then work from there
         if ($boolean === 'or') {
             $this->addFindRequest();
         }
+
+        if ($shouldBeOmit) {
+            $this->omit();
+        }
+
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -579,7 +579,6 @@ class FMBaseBuilder extends Builder
 
     public function whereIn($column, $values, $boolean = 'and', $not = false)
     {
-        dump([$column, $values, $boolean, $not, $this->currentFindRequestIndex]);
         if ($boolean === 'or' || $not) {
             $this->addFindRequest();
 
@@ -587,8 +586,6 @@ class FMBaseBuilder extends Builder
                 $this->omit();
             }
         }
-
-        dump($this->currentFindRequestIndex);
 
         if ($values instanceof Arrayable) {
             $values = $values->toArray();

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Middleware;
 use Illuminate\Database\Connection;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -449,7 +450,7 @@ class FileMakerConnection extends Connection
         return $response;
     }
 
-    protected function buildPostDataFromQuery(FMBaseBuilder $query)
+    public function buildPostDataFromQuery(FMBaseBuilder $query)
     {
         $postData = [];
 
@@ -553,12 +554,18 @@ class FileMakerConnection extends Connection
         }
 
         // if it's an array, it could be a file => filename key-value pair.
-        // it's a conainer if the first object in the array is a file
+        // it's a container if the first object in the array is a file
         if (is_array($field) && count($field) === 2 && $this->isFile($field[0])) {
             return true;
         }
 
         return false;
+    }
+
+    protected function isFile($object)
+    {
+        return is_a($object, \Illuminate\Http\File::class) ||
+            is_a($object, UploadedFile::class);
     }
 
     public function executeScript(FMBaseBuilder $query)

--- a/src/Support/Facades/FM.php
+++ b/src/Support/Facades/FM.php
@@ -14,13 +14,10 @@ use Illuminate\Support\Facades\Facade;
  * @method static FMBaseBuilder table($layoutName)
  * @method static FMBaseBuilder delete($recordId)
  * @method static FMBaseBuilder deleteByRecordId($recordId)
-
-
  * @method static array setGlobalFields(array $globalFields)
  * @method static FileMakerConnection connection(string $name = null)
  * @method static FileMakerConnection setRetries(int $retries)
  * @method static FileMakerConnection getLayoutMetadata($layoutName = null)
-
  *
  * @see \Illuminate\Database\DatabaseManager
  * @see FileMakerConnection


### PR DESCRIPTION
This PR adjusts the functionality of where method to make the method handle the boolean values set by whereNot method in Laravel's default builder classes.

Fixes #49