### PR TITLE
Improve compatibility with general eloquent usage and Laravel Nova

### DIFF
--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -1071,4 +1071,9 @@ class FMBaseBuilder extends Builder
         return is_null($value) && in_array($operator, $this->operators) &&
             ! in_array($operator, ['=', '==', '!=', '≠']);
     }
+
+    public function getCountForPagination($columns = ['*'])
+    {
+        return $this->count($columns);
+    }
 }

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -340,6 +340,12 @@ class FMBaseBuilder extends Builder
 
     public function orderBy($column, $direction = self::ASCEND): FMBaseBuilder
     {
+        $direction = match($direction) {
+            self::ASCEND, 'asc' => self::ASCEND,
+            self::DESCEND, 'desc' => self::DESCEND,
+            default => $direction
+        };
+
         $this->appendSortOrder($column, $direction);
 
         return $this;


### PR DESCRIPTION
This PR automatically corrects the sort order when using the `orderBy` query builder function. This is needed for compatibility with the`latest` and `oldest` methods, which by default use 'asc' or 'desc' for their order.

This also adds a `getCountForPagination` method override to return the correct FM count.

Both improve compatibility with Laravel Nova.