### PR TITLE
Create a pending FM request using the `Http` facade rather then directly

### DIFF
--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -693,7 +693,7 @@ class FileMakerConnection extends Connection
     protected function prepareRequestForSending($request = null)
     {
         if (! $request) {
-            $request = new PendingRequest();
+            $request = Http::createPendingRequest();
         }
 
         $request->retry($this->attempts, 100, fn () => true, false)->withToken($this->sessionToken);


### PR DESCRIPTION
This PR changes the creation of a new Http request towards the FM server, rather then calling `new PendingRequest()` the request gets created by calling the `Http` facade, this allows Events that are dispatched from the Http request to be handled in the framework. 

This was needed to allow the Http Client watcher from Laravel Telescope to function. Currently this does not register outgoing requests other then the request that gets sent when starting a new FM session (since this already calls the Http facade).