### PR TITLE
Add ability to limit portal results when using the Eloquent query builder

### DIFF
--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -336,9 +336,8 @@ class FMEloquentBuilder extends Builder
     /**
      * Set the limit of records returned for a portal on the current models' layout.
      *
-     * @param  string  $portalName Name of the portal
-     * @param  int  $limit Number of records to return
-     *
+     * @param  string  $portalName  Name of the portal
+     * @param  int  $limit  Number of records to return
      * @return $this
      */
     public function limitPortal(string $portalName, int $limit): static

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -332,4 +332,19 @@ class FMEloquentBuilder extends Builder
 
         return $result;
     }
+
+    /**
+     * Set the limit of records returned for a portal on the current models' layout.
+     *
+     * @param  string  $portalName Name of the portal
+     * @param  int  $limit Number of records to return
+     *
+     * @return $this
+     */
+    public function limitPortal(string $portalName, int $limit): static
+    {
+        $this->query->limitPortal($portalName, $limit);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
This PR adds the ability to increase the amount of returned portal records when using the Eloquent builder. This allows the user to have more then the default of 50 records returned when using the `FMModel`. 

For example; 
we have a layout 'Users' with a portal 'LogEntries' containing 100 lines. With the current version it is not possible to retrieve all log entries when having the User as an FMModel instance, since this always returns the default limit of 50 related records.

When this PR gets merged, we can instead chain the `limitPortal` method when retrieving a user and get all the logentries like this:
```php
$user = User::query()->limitPortal('LogEntries', 200)->first();
```