### PR TITLE
Fix for multiple attribute mutator support

### DIFF
--- a/src/Database/Eloquent/Concerns/FMHasAttributes.php
+++ b/src/Database/Eloquent/Concerns/FMHasAttributes.php
@@ -28,8 +28,6 @@ trait FMHasAttributes
             return $this;
         }
 
-        $value = $this->attributes[$key];
-
         // Check if we still have a DateTime object due to custom formatting and convert it to a string to write to FM.
         // Normally the SQL grammar would handle converting DateTime objects and SQL doesn't care about extra time data,
         // but FileMaker does, so we have to convert at this point and strip out times.

--- a/src/Database/Eloquent/Concerns/FMHasAttributes.php
+++ b/src/Database/Eloquent/Concerns/FMHasAttributes.php
@@ -18,6 +18,16 @@ trait FMHasAttributes
     {
         parent::setAttribute($key, $value);
 
+        /**
+         * If the key is set as a multiple attribute mutator and doesn't exist in the attributes array, then we can
+         * assume that the attribute is being set by the mutator and we should skip the rest of the processing.
+         */
+        if (array_key_exists($key, $this->attributes) === true) {
+            $value = $this->attributes[$key];
+        } else if (parent::hasAttributeSetMutator($key)) {
+            return $this;
+        }
+
         $value = $this->attributes[$key];
 
         // Check if we still have a DateTime object due to custom formatting and convert it to a string to write to FM.


### PR DESCRIPTION
So far, I was able to make a custom model accessor value for multiple attributes using `get` following the [official guide](https://laravel.com/docs/11.x/eloquent-mutators#building-value-objects-from-multiple-attributes).

However, [Mutating Multiple Attributes](https://laravel.com/docs/11.x/eloquent-mutators#mutating-multiple-attributes) was breaking because the `FMHasAttributes` model override method assumed the custom `$key` was part of the attributes array. That's not always the case with multiple attribute accessors and mutators.

This is a proposed fix using Laravel's native `hasAttributeSetMutator` to check using reflection classes if this is a client-only attribute definition.