### PR TITLE
use the HTTP facade instead of manually creating a new request

### DIFF
--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -697,7 +697,7 @@ class FileMakerConnection extends Connection
             if (method_exists(Factory::class, 'createPendingRequest')) {
                 $request = Http::createPendingRequest();
             } else {
-                $request = new PendingRequest();
+                $request = Http::acceptJson();
             }
         }
 


### PR DESCRIPTION
This allows consuming applications to use Http::fake() to mock the FileMaker Data API.

Prior to 2.2.1, I was able to do something like this in applications to mock the DAPI for my app tests:

```php

/** @param  array<string, string|\Illuminate\Http\Client\ResponseSequence|\GuzzleHttp\Promise\PromiseInterface>  $requests */
protected function mockFileMakerDataApi(array $requests = []): void
{
    $database = config('database.connections.filemaker.database');

    $sessionsUrl = sprintf(
        'https://%s/fmi/data/%s/databases/%s/sessions',
        config('database.connections.filemaker.host'),
        config('database.connections.filemaker.version'),
        $database,
    );

    Http::fake(array_merge([
        $sessionsUrl => Http::response(['response' => ['token' => 'fake-token']], 200),
    ], $requests));
}

$this->mockFileMakerDataApi([
    'https://server/fmi/data/databases/database/layouts/test/*' => Http::response([/** fake data */]),
]);
```

---

Since 7b94af3ee82d18f36713e58bfe820bf0ccce70ea specifically, I now get an error:

```
  Layout: test - Authorization header missing 'Basic' or 'Bearer'.

  at vendor/gearbox-solutions/eloquent-filemaker/src/Services/FileMakerConnection.php:176
    172▕                         $customMessage = 'Layout: '.$this->getLayout().' - '.$message['message'];
    173▕                     } else {
    174▕                         $customMessage = $message['message'];
    175▕                     }
  ➜ 176▕                     throw new FileMakerDataApiException($customMessage, $code);
    177▕                 }
    178▕             }
    179▕         } else {
    180▕             $response->throw();

      +11 vendor frames 
```

Because the `new PendingRequest()` does not know about the already-faked responses it should return, it tries to run real requests.

---

Solution: upgrade Laravel to ^[11.3.0](https://github.com/laravel/framework/releases/tag/v11.3.0) to take advantage of the new `Http::createPendingRequest()` 😆 

Alternate solution for older apps: use `Http::acceptJson()` to create the pending request while retaining knowledge of faked requests.