### PR TITLE
flatten bindings for Telescope

### DIFF
--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -766,9 +766,9 @@ class FileMakerConnection extends Connection
 
         $this->event(new QueryExecuted(
             $sql,
-            collect(data_get($params, 'query', []))->map(
-                fn (array $binding, $index) => collect($binding)->map(fn ($value, $key) => $index . ': ' . $key . ': ' . $value)
-            )->flatten()->all(),
+            collect(data_get($params, 'query', []))->flatMap(
+                fn (array $binding, $index) => collect($binding)->mapWithKeys(fn ($value, $key) => [$index.': '.$key => $value])
+            )->all(),
             $this->getElapsedTime($start),
             $this,
         ));

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -764,11 +764,13 @@ class FileMakerConnection extends Connection
             $sql .= "\nData: " . json_encode($params, JSON_PRETTY_PRINT);
         }
 
+        $bindings = collect(data_get($params, 'query', []))->flatMap(
+            fn (array $binding, $index) => collect($binding)->mapWithKeys(fn ($value, $key) => [$index . ': ' . $key => $value])
+        )->all();
+
         $this->event(new QueryExecuted(
             $sql,
-            collect(data_get($params, 'query', []))->flatMap(
-                fn (array $binding, $index) => collect($binding)->mapWithKeys(fn ($value, $key) => [$index.': '.$key => $value])
-            )->all(),
+            $bindings,
             $this->getElapsedTime($start),
             $this,
         ));
@@ -816,7 +818,7 @@ class FileMakerConnection extends Connection
 
     protected function getDefaultQueryGrammar()
     {
-        return new FMGrammar();
+        return new FMGrammar;
     }
 
     //    public function getLayoutMetadata($layout = null)

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -767,10 +767,8 @@ class FileMakerConnection extends Connection
         $this->event(new QueryExecuted(
             $sql,
             collect(data_get($params, 'query', []))->map(
-                fn (array $binding) => collect($binding)
-                    ->map(fn ($value, $key) => $key . ': ' . $value)
-                    ->join(', ')
-            )->all(),
+                fn (array $binding, $index) => collect($binding)->map(fn ($value, $key) => $index . ': ' . $key . ': ' . $value)
+            )->flatten()->all(),
             $this->getElapsedTime($start),
             $this,
         ));

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -767,7 +767,9 @@ class FileMakerConnection extends Connection
         $this->event(new QueryExecuted(
             $sql,
             collect(data_get($params, 'query', []))->map(
-                fn (array $binding) => array_keys($binding)[0] . ': ' . array_values($binding)[0]
+                fn (array $binding) => collect($binding)
+                    ->map(fn ($value, $key) => $key . ': ' . $value)
+                    ->join(', ')
             )->all(),
             $this->getElapsedTime($start),
             $this,
@@ -816,7 +818,7 @@ class FileMakerConnection extends Connection
 
     protected function getDefaultQueryGrammar()
     {
-        return new FMGrammar();
+        return new FMGrammar;
     }
 
     //    public function getLayoutMetadata($layout = null)

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -818,7 +818,7 @@ class FileMakerConnection extends Connection
 
     protected function getDefaultQueryGrammar()
     {
-        return new FMGrammar;
+        return new FMGrammar();
     }
 
     //    public function getLayoutMetadata($layout = null)

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -764,7 +764,14 @@ class FileMakerConnection extends Connection
             $sql .= "\nData: " . json_encode($params, JSON_PRETTY_PRINT);
         }
 
-        $this->event(new QueryExecuted($sql, Arr::get($params, 'query', []), $this->getElapsedTime($start), $this));
+        $this->event(new QueryExecuted(
+            $sql,
+            collect(data_get($params, 'query', []))->map(
+                fn (array $binding) => array_keys($binding)[0] . ': ' . array_values($binding)[0]
+            )->all(),
+            $this->getElapsedTime($start),
+            $this,
+        ));
     }
 
     protected function getSqlCommandType($method, $url)


### PR DESCRIPTION
Once https://github.com/laravel/telescope/pull/1499 is merged, this will cause an error due to the deeper array syntax that FM queries use.

Before, the bindings result in this shape:

```php
[
    ['kp_id' => 'ABC123'],
    ['kp_id' => 'ABC124'],
    ['kp_id' => 'ABC125'],
];
```

After:

```php
[
    'kp_id: ABC123',
    'kp_id: ABC124',
    'kp_id: ABC125',
];
```