### PR TITLE
add flag to disable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ You may use the following code block below as a template, which has some good de
     'protocol' => env('DB_PROTOCOL', 'https'),
     'cache_session_token' => env('DB_CACHE_SESSION_TOKEN', true), // set to false to log out after each reqeust. This can be slower than re-using a session token, but allows for globals to be set for individual user values.
     'empty_strings_to_null' => env('DB_EMPTY_STRINGS_TO_NULL', true), // set to false to return empty strings instead of null values when fields are empty in FileMaker
+    'enable_query_logging' => env('FM_ENABLE_QUERY_LOGGING', true), // set to false to disable query logging
 ]
 ```
 You should add one database connection configuration for each FileMaker database you will be connecting to. Each file can have completely different configurations, and can even be on different servers.

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -41,11 +41,14 @@ class FileMakerConnection extends Connection
 
     protected bool $emptyStringToNull = true;
 
+    protected bool $enableLogging = true;
+
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {
 
         $this->emptyStringToNull = $config['empty_strings_to_null'] ?? true;
         $this->shouldCacheSessionToken = $config['cache_session_token'] ?? true;
+        $this->enableLogging = $config['enable_logging'] ?? true;
 
         // set the session cache key with the name of the connection to support multiple connections
         $this->sessionTokenCacheKey = 'eloquent-filemaker-session-token-' . $config['name'];
@@ -751,6 +754,10 @@ class FileMakerConnection extends Connection
 
     protected function logFMQuery($method, $url, $params, $start)
     {
+        if (! $this->enableLogging) {
+            return;
+        }
+
         $commandType = $this->getSqlCommandType($method, $url);
 
         // Clockwork specifically looks for the commandType as the first word in the "sql" string


### PR DESCRIPTION
I’m using a mysql database for my app, as well as this package to access a FileMaker database for some additional data.

I’m also using Laravel Telescope, which listens to the `\Illuminate\Database\Events\QueryExecuted` event.

However, that results in `ERROR  Call to a member function quote() on string in vendor/laravel/telescope/src/Watchers/QueryWatcher.php on line 122.` in Telescope because [this line](https://github.com/laravel/telescope/blob/a678a14018f27df566b5478804b530fdf618c812/src/Watchers/QueryWatcher.php#L122) is trying to get a `PDO` instance.

This PR adds the ability to disable query logging just for FM queries, while leaving it on for mysql queries. The alternative would be to totally disable query logging in Telescope.