### PR TITLE
added withModId function

### DIFF
--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -168,7 +168,7 @@ class FMEloquentBuilder extends Builder
         }
 
         // set the ModID if that option is set on the model
-        if ($model->withModId()) {
+        if ($model->usingModId()) {
             $this->query->modId($model->getModId());
         }
 

--- a/src/Database/Eloquent/FMEloquentBuilder.php
+++ b/src/Database/Eloquent/FMEloquentBuilder.php
@@ -167,6 +167,11 @@ class FMEloquentBuilder extends Builder
             }
         }
 
+        // set the ModID if that option is set on the model
+        if ($model->withModId()) {
+            $this->query->modId($model->getModId());
+        }
+
         if ($fieldsToWrite->count() > 0 || count($modifiedPortals) > 0) {
             // we have some regular text fields to update
             // forward this request to a base query builder to execute the edit record request

--- a/src/Database/Eloquent/FMModel.php
+++ b/src/Database/Eloquent/FMModel.php
@@ -65,6 +65,8 @@ abstract class FMModel extends Model
      */
     protected $modId;
 
+    protected $useModId = false;
+
     /**
      * The "type" of the primary key ID. FileMaker uses UUID strings by default.
      *
@@ -217,6 +219,17 @@ abstract class FMModel extends Model
     public function setModId($modId): void
     {
         $this->modId = $modId;
+    }
+
+    /**
+     * Include the modification Id when editing a record
+     */
+    public function withModId($include = true): self
+    {
+        // remove any set ModId if the user wishes to remove it
+        $this->useModId = $include;
+
+        return $this;
     }
 
     public function getReadOnlyFields()

--- a/src/Database/Eloquent/FMModel.php
+++ b/src/Database/Eloquent/FMModel.php
@@ -224,12 +224,17 @@ abstract class FMModel extends Model
     /**
      * Include the modification Id when editing a record
      */
-    public function withModId($include = true): self
+    public function withModId($include = true): static
     {
         // remove any set ModId if the user wishes to remove it
         $this->useModId = $include;
 
         return $this;
+    }
+
+    public function usingModId(): bool
+    {
+        return $this->useModId;
     }
 
     public function getReadOnlyFields()


### PR DESCRIPTION
There was no way to submit the Mod ID with an eloquent model, so this has been adde in as a `withModId()` function to call before calling `save()`