### PR TITLE
Security tightening around logging, request paths, and cache handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ You may use the following code block below as a template, which has some good de
     'prefix' => env('DB_PREFIX', ''),
     'version' => env('DB_VERSION', 'vLatest'),
     'protocol' => env('DB_PROTOCOL', 'https'),
+    'allow_insecure_http' => env('DB_ALLOW_INSECURE_HTTP', false), // must be true to use protocol=http without a warning
+    'verify_ssl' => env('DB_VERIFY_SSL', true), // set to false for self-signed certs, or a path to a CA bundle
     'cache_session_token' => env('DB_CACHE_SESSION_TOKEN', true), // set to false to log out after each reqeust. This can be slower than re-using a session token, but allows for globals to be set for individual user values.
+    'session_token_ttl' => env('DB_SESSION_TOKEN_TTL', 840), // session token cache TTL in seconds (default 14 min, just under FM's 15 min timeout)
     'empty_strings_to_null' => env('DB_EMPTY_STRINGS_TO_NULL', true), // set to false to return empty strings instead of null values when fields are empty in FileMaker
     'request_timeout' => env('DB_REQUEST_TIMEOUT', 30), // set the request timeout in seconds (default 30)
+    'redact_query_logs' => env('DB_REDACT_QUERY_LOGS', false), // set to true to mask fieldData, portalData, globalFields and script params in query log events
 ]
 ```
 You should add one database connection configuration for each FileMaker database you will be connecting to. Each file can have completely different configurations, and can even be on different servers.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.2",
     "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
     "guzzlehttp/guzzle": "^7.5",
     "ext-json": "*"

--- a/src/Database/Eloquent/Concerns/FMGuardsAttributes.php
+++ b/src/Database/Eloquent/Concerns/FMGuardsAttributes.php
@@ -44,7 +44,7 @@ trait FMGuardsAttributes
 
     protected function primeGuardableColumns($forceRefresh = false)
     {
-        if (! isset(static::$guardableColumns[get_class($this)])) {
+        if ($forceRefresh || ! isset(static::$guardableColumns[get_class($this)])) {
             $columns = $this->getColumns($forceRefresh);
 
             if (empty($columns)) {
@@ -56,7 +56,10 @@ trait FMGuardsAttributes
 
     protected function getColumns($forceRefresh = false): array
     {
-        $cacheKey = "eloquent-filemaker-{$this->table}-columns";
+        // Include connection name to prevent collisions when two connections share a layout name
+        $connectionName = $this->getConnectionName() ?? 'default';
+        $cacheKey = "eloquent-filemaker-{$connectionName}-{$this->table}-columns";
+
         $refreshCallback = function () {
             $layoutMetaData = $this->getConnection()->getLayoutMetadata($this->table);
 

--- a/src/Database/Query/FMBaseBuilder.php
+++ b/src/Database/Query/FMBaseBuilder.php
@@ -333,6 +333,10 @@ class FMBaseBuilder extends Builder
      */
     public function recordId($recordId)
     {
+        if ($recordId !== null && ! is_numeric($recordId)) {
+            throw new InvalidArgumentException('Record ID must be numeric, got: ' . gettype($recordId));
+        }
+
         $this->recordId = $recordId;
 
         return $this;

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -146,7 +146,7 @@ class FileMakerConnection extends Connection
 
     protected function getDatabaseUrl()
     {
-        return ($this->config['protocol'] ?? 'https') . '://' . $this->config['host'] . '/fmi/data/' . ($this->config['version'] ?? 'vLatest') . '/databases/' . $this->config['database'];
+        return ($this->config['protocol'] ?? 'https') . '://' . $this->config['host'] . '/fmi/data/' . ($this->config['version'] ?? 'vLatest') . '/databases/' . $this->encodePathSegment($this->config['database']);
     }
 
     protected function getRecordUrl()
@@ -161,7 +161,12 @@ class FileMakerConnection extends Connection
             $this->setLayout($layout);
         }
 
-        return $this->getDatabaseUrl() . '/layouts/' . $this->getLayout();
+        return $this->getDatabaseUrl() . '/layouts/' . $this->encodePathSegment($this->getLayout());
+    }
+
+    protected function encodePathSegment(string $value): string
+    {
+        return rawurlencode($value);
     }
 
     /**
@@ -195,7 +200,7 @@ class FileMakerConnection extends Connection
     public function uploadToContainerField(FMBaseBuilder $query)
     {
         $this->setLayout($query->from);
-        $url = $this->getRecordUrl() . $query->getRecordId() . '/containers/' . $query->containerFieldName;
+        $url = $this->getRecordUrl() . $query->getRecordId() . '/containers/' . $this->encodePathSegment($query->containerFieldName);
 
         /*
          * The user can insert an array for the file to specify the file name, so we can check for that here
@@ -642,7 +647,7 @@ class FileMakerConnection extends Connection
     public function executeScript(FMBaseBuilder $query)
     {
         $this->setLayout($query->from);
-        $url = $this->getLayoutUrl() . '/script/' . $query->script;
+        $url = $this->getLayoutUrl() . '/script/' . $this->encodePathSegment($query->script);
 
         $queryParams = [];
         $param = $query->scriptParam;

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -59,6 +59,17 @@ class FileMakerConnection extends Connection
 
         $this->setTimeout($config['request_timeout'] ?? 30);
 
+        // Warn when using plain HTTP since credentials will be sent in cleartext
+        $protocol = $config['protocol'] ?? 'https';
+        if ($protocol === 'http' && ! ($config['allow_insecure_http'] ?? false)) {
+            trigger_error(
+                'FileMaker connection "' . ($config['name'] ?? '') . '" uses plain HTTP. '
+                . 'Credentials will be sent in cleartext. Set allow_insecure_http=true to suppress this warning, '
+                . 'or switch to HTTPS.',
+                E_USER_WARNING
+            );
+        }
+
         parent::__construct($pdo, $database, $tablePrefix, $config);
     }
 
@@ -125,8 +136,9 @@ class FileMakerConnection extends Connection
 
         // perform the login
         try {
-            $response = Http::retry($this->attempts, 100)->withBasicAuth($this->config['username'], $this->config['password'])
-                ->post($url, $postBody);
+            $loginRequest = Http::retry($this->attempts, 100)->withBasicAuth($this->config['username'], $this->config['password']);
+            $this->applyTlsOptions($loginRequest);
+            $response = $loginRequest->post($url, $postBody);
         } catch (\Exception $e) {
             $this->logFMQuery('post', $url, $logBody, $start);
             throw $e;
@@ -686,7 +698,9 @@ class FileMakerConnection extends Connection
         $url = $this->getDatabaseUrl() . '/sessions/' . $this->sessionToken;
 
         // make an http delete request to the data api to end the session
-        $response = Http::delete($url);
+        $request = Http::createPendingRequest();
+        $this->applyTlsOptions($request);
+        $response = $request->delete($url);
         $this->checkResponseForErrors($response);
 
         $this->forgetSessionToken();
@@ -740,7 +754,21 @@ class FileMakerConnection extends Connection
             ->retry($this->attempts, 100, fn () => true, false)
             ->withToken($this->sessionToken);
 
+        $this->applyTlsOptions($request);
+
         return $request;
+    }
+
+    protected function applyTlsOptions(PendingRequest $request): void
+    {
+        $verify = $this->config['verify_ssl'] ?? true;
+
+        if (is_string($verify)) {
+            // Treat as path to a CA bundle
+            $request->withOptions(['verify' => $verify]);
+        } elseif ($verify === false) {
+            $request->withoutVerifying();
+        }
     }
 
     /**

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -118,24 +118,25 @@ class FileMakerConnection extends Connection
             ],
         ];
 
+        // Build a redacted copy for logging so credentials never reach listeners
+        $logBody = $postBody;
+        Arr::set($logBody, 'fmDataSource.0.username', str_repeat('*', strlen(Arr::get($logBody, 'fmDataSource.0.username'))));
+        Arr::set($logBody, 'fmDataSource.0.password', str_repeat('*', strlen(Arr::get($logBody, 'fmDataSource.0.password'))));
+
         // perform the login
         try {
             $response = Http::retry($this->attempts, 100)->withBasicAuth($this->config['username'], $this->config['password'])
                 ->post($url, $postBody);
         } catch (\Exception $e) {
-            // log the query even on an error
-            $this->logFMQuery('post', $url, $postBody, $start);
+            $this->logFMQuery('post', $url, $logBody, $start);
             throw $e;
         }
 
-        // log the query
-        $this->logFMQuery('post', $url, $postBody, $start);
+        // log the query with redacted credentials
+        $this->logFMQuery('post', $url, $logBody, $start);
 
         // Check for errors
         $this->checkResponseForErrors($response);
-
-        Arr::set($postBody, 'fmDataSource.0.username', str_repeat('*', strlen(Arr::get($postBody, 'fmDataSource.0.username'))));
-        Arr::set($postBody, 'fmDataSource.0.password', str_repeat('*', strlen(Arr::get($postBody, 'fmDataSource.0.password'))));
 
         // Get the session token from the response
         $token = Arr::get($response, 'response.token');
@@ -166,7 +167,7 @@ class FileMakerConnection extends Connection
     /**
      * @throws FileMakerDataApiException
      */
-    protected function checkResponseForErrors($response): void
+    protected function checkResponseForErrors(#[\SensitiveParameter] $response): void
     {
         $messages = Arr::get($response, 'messages', []);
 
@@ -720,7 +721,7 @@ class FileMakerConnection extends Connection
         return $response;
     }
 
-    protected function prepareRequestForSending($request = null)
+    protected function prepareRequestForSending(#[\SensitiveParameter] $request = null)
     {
         if (! $request) {
             if (method_exists(Factory::class, 'createPendingRequest')) {
@@ -740,7 +741,7 @@ class FileMakerConnection extends Connection
     /**
      * @throws FileMakerDataApiException
      */
-    protected function makeRequest($method, $url, $params = [], ?PendingRequest $request = null)
+    protected function makeRequest($method, $url, #[\SensitiveParameter] $params = [], #[\SensitiveParameter] ?PendingRequest $request = null)
     {
         $start = microtime(true);
 
@@ -798,7 +799,7 @@ class FileMakerConnection extends Connection
         return $json;
     }
 
-    protected function logFMQuery($method, $url, $params, $start)
+    protected function logFMQuery($method, $url, #[\SensitiveParameter] $params, $start)
     {
         $commandType = $this->getSqlCommandType($method, $url);
 

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -220,6 +220,9 @@ class FileMakerConnection extends Connection
          * [ $file, 'myFile.pdf' ]
          */
         if (is_array($query->containerFile)) {
+            if (count($query->containerFile) !== 2 || ! $this->isFile($query->containerFile[0]) || ! is_string($query->containerFile[1])) {
+                throw new \InvalidArgumentException('Container file array must be [$file, $filename]');
+            }
             // we have a file and file name
             $file = $query->containerFile[0];
             $filename = $query->containerFile[1];
@@ -228,6 +231,8 @@ class FileMakerConnection extends Connection
             $filename = $file->getFilename();
         }
 
+        $filename = $this->sanitizeFilename($filename);
+
         // create a stream resource
         $stream = fopen($file->getPath() . '/' . $file->getFilename(), 'r');
 
@@ -235,6 +240,19 @@ class FileMakerConnection extends Connection
         $response = $this->makeRequest('post', $url, [], $request);
 
         return $response;
+    }
+
+    protected function sanitizeFilename(string $filename): string
+    {
+        // Strip null bytes, path separators, and control characters
+        $filename = str_replace(["\0", '/', '\\'], '', $filename);
+        $filename = preg_replace('/[\x00-\x1F\x7F]/', '', $filename);
+
+        if ($filename === '') {
+            $filename = 'upload';
+        }
+
+        return $filename;
     }
 
     public function getSingleRecordById(FMBaseBuilder $query)

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -102,7 +102,9 @@ class FileMakerConnection extends Connection
         // retrieve and store the session token
         // Store it in the cache if the connection is configured to do so
         if ($this->shouldCacheSessionToken) {
-            $this->sessionToken = Cache::rememberForever($this->sessionTokenCacheKey, function () {
+            // Default to 14 minutes, just under FileMaker's default 15-minute session timeout
+            $ttl = $this->config['session_token_ttl'] ?? 840;
+            $this->sessionToken = Cache::remember($this->sessionTokenCacheKey, $ttl, function () {
                 return $this->fetchNewSessionToken();
             });
         } else {

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -717,8 +717,13 @@ class FileMakerConnection extends Connection
 
         $url = $this->getDatabaseUrl() . '/sessions/' . $this->sessionToken;
 
-        // make an http delete request to the data api to end the session
-        $request = Http::createPendingRequest();
+        // Laravel 10 does not expose createPendingRequest(); once Laravel 10 support is dropped,
+        // this fallback can go away and we can use Http::createPendingRequest() directly here.
+        if (method_exists(Factory::class, 'createPendingRequest')) {
+            $request = Http::createPendingRequest();
+        } else {
+            $request = Http::acceptJson();
+        }
         $this->applyTlsOptions($request);
         $response = $request->delete($url);
         $this->checkResponseForErrors($response);
@@ -763,6 +768,8 @@ class FileMakerConnection extends Connection
     protected function prepareRequestForSending(#[\SensitiveParameter] $request = null)
     {
         if (! $request) {
+            // Laravel 10 does not expose createPendingRequest(); once Laravel 10 support is dropped,
+            // this fallback can go away and we can use Http::createPendingRequest() directly here.
             if (method_exists(Factory::class, 'createPendingRequest')) {
                 $request = Http::createPendingRequest();
             } else {

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -25,7 +25,7 @@ class FileMakerConnection extends Connection
 
     protected ?string $host;
 
-    protected ?string $layout;
+    protected ?string $layout = null;
 
     protected ?string $username;
 
@@ -78,7 +78,7 @@ class FileMakerConnection extends Connection
      */
     public function getLayout()
     {
-        return $this->tablePrefix . $this->layout;
+        return $this->tablePrefix . ($this->layout ?? '');
     }
 
     public function login()

--- a/src/Services/FileMakerConnection.php
+++ b/src/Services/FileMakerConnection.php
@@ -195,8 +195,8 @@ class FileMakerConnection extends Connection
                 if ($code !== 0) {
 
                     // If the layout is not the same as the table prefix, a layout has been specified and we
-                    // should to add the layout name for clarity
-                    if ($this->layout) {
+                    // should to add the layout name for clarity (only in debug mode to avoid leaking internals)
+                    if (config('app.debug', false) && $this->layout) {
                         $customMessage = 'Layout: ' . $this->getLayout() . ' - ' . $message['message'];
                     } else {
                         $customMessage = $message['message'];
@@ -843,8 +843,18 @@ class FileMakerConnection extends Connection
                 URL: {$url}
                 DOC;
 
-        if (count($params) > 0) {
-            $sql .= "\nData: " . json_encode($params, JSON_PRETTY_PRINT);
+        $logParams = $params;
+        if ($this->config['redact_query_logs'] ?? false) {
+            $redactKeys = ['fieldData', 'portalData', 'globalFields', 'script.param', 'script.prerequest.param', 'script.presort.param'];
+            foreach ($redactKeys as $key) {
+                if (Arr::has($logParams, $key)) {
+                    Arr::set($logParams, $key, '[redacted]');
+                }
+            }
+        }
+
+        if (count($logParams) > 0) {
+            $sql .= "\nData: " . json_encode($logParams, JSON_PRETTY_PRINT);
         }
 
         $bindings = collect(data_get($params, 'query', []))->flatMap(

--- a/tests/Unit/FileMakerConnectionTest.php
+++ b/tests/Unit/FileMakerConnectionTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Unit;
 
 use GearboxSolutions\EloquentFileMaker\Services\FileMakerConnection;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Mockery;
 use Tests\TestCase;
@@ -90,6 +92,40 @@ class FileMakerConnectionTest extends TestCase
         $token = Cache::get('filemaker-session-' . $connection->getName());
 
         $this->assertEquals('new-token', $token);
+    }
+
+    public function test_login_query_log_does_not_contain_raw_credentials()
+    {
+        $this->overrideDBHost();
+        Http::fake([
+            'http://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response([
+                'messages' => [['code' => '0', 'message' => 'OK']],
+                'response' => ['token' => 'test-token'],
+            ], 200),
+        ]);
+
+        $loggedSql = [];
+        $this->app['events']->listen(QueryExecuted::class, function (QueryExecuted $event) use (&$loggedSql) {
+            $loggedSql[] = $event->sql;
+        });
+
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'dapitester',
+            'password' => 'dapitester',
+            'protocol' => 'http',
+            'cache_session_token' => false,
+        ]);
+        $connection->setEventDispatcher($this->app['events']);
+
+        $connection->login();
+
+        $this->assertNotEmpty($loggedSql, 'Expected at least one query log entry from login');
+
+        $combined = implode(' ', $loggedSql);
+        $this->assertStringNotContainsString('dapitester', $combined, 'Raw credentials should not appear in query log');
     }
 
     protected function overrideDBHost()

--- a/tests/Unit/FileMakerConnectionTest.php
+++ b/tests/Unit/FileMakerConnectionTest.php
@@ -170,6 +170,70 @@ class FileMakerConnectionTest extends TestCase
         $this->assertEquals(42, $builder->getRecordId());
     }
 
+    public function test_http_protocol_triggers_warning()
+    {
+        $triggered = false;
+        set_error_handler(function ($errno, $errstr) use (&$triggered) {
+            if (str_contains($errstr, 'uses plain HTTP')) {
+                $triggered = true;
+            }
+
+            return true;
+        });
+
+        try {
+            new FileMakerConnection('filemaker', 'tester', '', [
+                'name' => 'filemaker',
+                'host' => 'filemaker.test',
+                'database' => 'tester',
+                'username' => 'test',
+                'password' => 'test',
+                'protocol' => 'http',
+            ]);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue($triggered, 'Expected a warning about plain HTTP');
+    }
+
+    public function test_http_protocol_with_opt_in_does_not_warn()
+    {
+        // Should not trigger a warning
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'test',
+            'password' => 'test',
+            'protocol' => 'http',
+            'allow_insecure_http' => true,
+        ]);
+
+        $this->assertInstanceOf(FileMakerConnection::class, $connection);
+    }
+
+    public function test_verify_ssl_false_disables_verification()
+    {
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'test',
+            'password' => 'test',
+            'protocol' => 'https',
+            'verify_ssl' => false,
+            'cache_session_token' => false,
+        ]);
+
+        $ref = new \ReflectionMethod($connection, 'prepareRequestForSending');
+        $request = $ref->invoke($connection);
+
+        // The pending request options should have verify=false
+        $options = $request->getOptions();
+        $this->assertFalse($options['verify']);
+    }
+
     protected function overrideDBHost()
     {
         Config::set('database.connections.filemaker.host', 'filemaker.test');

--- a/tests/Unit/FileMakerConnectionTest.php
+++ b/tests/Unit/FileMakerConnectionTest.php
@@ -234,6 +234,127 @@ class FileMakerConnectionTest extends TestCase
         $this->assertFalse($options['verify']);
     }
 
+    public function test_redact_query_logs_masks_field_data()
+    {
+        Http::fake([
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response([
+                'messages' => [['code' => '0', 'message' => 'OK']],
+                'response' => ['token' => 'test-token'],
+            ], 200),
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/layouts/pets/records/*' => Http::response([
+                'messages' => [['code' => '0', 'message' => 'OK']],
+                'response' => [],
+            ], 200),
+        ]);
+
+        $loggedSql = [];
+        $this->app['events']->listen(QueryExecuted::class, function (QueryExecuted $event) use (&$loggedSql) {
+            $loggedSql[] = $event->sql;
+        });
+
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'test',
+            'password' => 'test',
+            'protocol' => 'https',
+            'cache_session_token' => false,
+            'redact_query_logs' => true,
+        ]);
+        $connection->setEventDispatcher($this->app['events']);
+
+        $query = $connection->query();
+        $query->from = 'pets';
+        $query->recordId(1);
+        $query->fieldData = ['name' => 'secret-value'];
+
+        try {
+            $connection->editRecord($query);
+        } catch (\Exception $e) {
+            // Expected since we're faking
+        }
+
+        $combined = implode(' ', $loggedSql);
+        $this->assertStringNotContainsString('secret-value', $combined, 'fieldData should be redacted');
+        $this->assertStringContainsString('[redacted]', $combined);
+    }
+
+    public function test_default_logging_preserves_field_data()
+    {
+        Http::fake([
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response([
+                'messages' => [['code' => '0', 'message' => 'OK']],
+                'response' => ['token' => 'test-token'],
+            ], 200),
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/layouts/pets/records/*' => Http::response([
+                'messages' => [['code' => '0', 'message' => 'OK']],
+                'response' => [],
+            ], 200),
+        ]);
+
+        $loggedSql = [];
+        $this->app['events']->listen(QueryExecuted::class, function (QueryExecuted $event) use (&$loggedSql) {
+            $loggedSql[] = $event->sql;
+        });
+
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'test',
+            'password' => 'test',
+            'protocol' => 'https',
+            'cache_session_token' => false,
+            // redact_query_logs not set, defaults to false
+        ]);
+        $connection->setEventDispatcher($this->app['events']);
+
+        $query = $connection->query();
+        $query->from = 'pets';
+        $query->recordId(1);
+        $query->fieldData = ['name' => 'visible-value'];
+
+        try {
+            $connection->editRecord($query);
+        } catch (\Exception $e) {
+            // Expected
+        }
+
+        $combined = implode(' ', $loggedSql);
+        $this->assertStringContainsString('visible-value', $combined, 'fieldData should be visible when redaction is off');
+    }
+
+    public function test_exception_hides_layout_in_production()
+    {
+        Config::set('app.debug', false);
+
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'test',
+            'password' => 'test',
+            'protocol' => 'https',
+            'cache_session_token' => false,
+        ]);
+        $connection->setLayout('secret-layout');
+
+        $fakeResponse = new \Illuminate\Http\Client\Response(
+            new \GuzzleHttp\Psr7\Response(200, [], json_encode([
+                'messages' => [['code' => '401', 'message' => 'No records match']],
+            ]))
+        );
+
+        try {
+            $ref = new \ReflectionMethod($connection, 'checkResponseForErrors');
+            $ref->invoke($connection, $fakeResponse);
+            $this->fail('Expected exception');
+        } catch (\Exception $e) {
+            $this->assertStringNotContainsString('secret-layout', $e->getMessage());
+        }
+    }
+
     protected function overrideDBHost()
     {
         Config::set('database.connections.filemaker.host', 'filemaker.test');

--- a/tests/Unit/FileMakerConnectionTest.php
+++ b/tests/Unit/FileMakerConnectionTest.php
@@ -6,7 +6,6 @@ use GearboxSolutions\EloquentFileMaker\Services\FileMakerConnection;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Mockery;
 use Tests\TestCase;
@@ -19,11 +18,12 @@ class FileMakerConnectionTest extends TestCase
     protected function tearDown(): void
     {
         Mockery::close();
+        parent::tearDown();
     }
 
     public function test_connection_gets_the_default_database_configuration()
     {
-        $connection = app(FileMakerConnection::class);
+        $connection = $this->connection();
 
         $this->assertEquals('filemaker', $connection->getConfig('name'));
         $this->assertEquals('tester', $connection->getConfig('database'));
@@ -31,11 +31,11 @@ class FileMakerConnectionTest extends TestCase
 
     public function test_set_connection_changes_the_database_configuration()
     {
-        $connection = app(FileMakerConnection::class);
+        $connection = $this->connection();
         $this->assertEquals('filemaker', $connection->getConfig('name'));
         $this->assertEquals('tester', $connection->getConfig('database'));
 
-        $connection->setConnection('filemaker2');
+        $connection = $this->connection('filemaker2');
 
         $this->assertEquals('filemaker2', $connection->getConfig('name'));
         $this->assertEquals('tester2', $connection->getConfig('database'));
@@ -43,7 +43,7 @@ class FileMakerConnectionTest extends TestCase
 
     public function test_set_layout_changes_the_layout_used()
     {
-        $connection = app(FileMakerConnection::class);
+        $connection = $this->connection();
         $this->assertEquals('', $connection->getLayout());
 
         $connection->setLayout('dapi-pet');
@@ -53,7 +53,7 @@ class FileMakerConnectionTest extends TestCase
 
     public function test_database_prefix_is_added_to_layout_names()
     {
-        $connection = app(FileMakerConnection::class)->setConnection('prefix');
+        $connection = $this->connection('prefix');
 
         $this->assertEquals('dapi-', $connection->getLayout());
 
@@ -68,13 +68,13 @@ class FileMakerConnectionTest extends TestCase
     {
         $this->overrideDBHost();
         Http::fake([
-            'http://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200),
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200),
         ]);
-        $connection = app(FileMakerConnection::class)->setConnection('filemaker');
+        $connection = $this->connection();
 
         $connection->login();
 
-        $token = Cache::get('filemaker-session-' . $connection->getName());
+        $token = Cache::get('eloquent-filemaker-session-token-' . $connection->getName());
 
         $this->assertEquals('new-token', $token);
     }
@@ -83,13 +83,13 @@ class FileMakerConnectionTest extends TestCase
     {
         $this->overrideDBHost();
         Http::fake([
-            'http://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200),
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response(['response' => ['token' => 'new-token']], 200),
         ]);
-        $connection = app(FileMakerConnection::class)->setConnection('filemaker');
+        $connection = $this->connection();
 
         $connection->login();
 
-        $token = Cache::get('filemaker-session-' . $connection->getName());
+        $token = Cache::get('eloquent-filemaker-session-token-' . $connection->getName());
 
         $this->assertEquals('new-token', $token);
     }
@@ -98,7 +98,7 @@ class FileMakerConnectionTest extends TestCase
     {
         $this->overrideDBHost();
         Http::fake([
-            'http://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response([
+            'https://filemaker.test/fmi/data/vLatest/databases/tester/sessions' => Http::response([
                 'messages' => [['code' => '0', 'message' => 'OK']],
                 'response' => ['token' => 'test-token'],
             ], 200),
@@ -115,7 +115,7 @@ class FileMakerConnectionTest extends TestCase
             'database' => 'tester',
             'username' => 'dapitester',
             'password' => 'dapitester',
-            'protocol' => 'http',
+            'protocol' => 'https',
             'cache_session_token' => false,
         ]);
         $connection->setEventDispatcher($this->app['events']);
@@ -131,6 +131,11 @@ class FileMakerConnectionTest extends TestCase
     protected function overrideDBHost()
     {
         Config::set('database.connections.filemaker.host', 'filemaker.test');
-        Config::set('database.connections.filemaker.protocol', 'http');
+        Config::set('database.connections.filemaker.protocol', 'https');
+    }
+
+    protected function connection(string $name = 'filemaker'): FileMakerConnection
+    {
+        return app('db')->connection($name);
     }
 }

--- a/tests/Unit/FileMakerConnectionTest.php
+++ b/tests/Unit/FileMakerConnectionTest.php
@@ -355,6 +355,50 @@ class FileMakerConnectionTest extends TestCase
         }
     }
 
+    public function test_container_upload_sanitizes_filename()
+    {
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'test',
+            'password' => 'test',
+            'protocol' => 'https',
+            'cache_session_token' => false,
+        ]);
+
+        $ref = new \ReflectionMethod($connection, 'sanitizeFilename');
+
+        $this->assertEquals('test.pdf', $ref->invoke($connection, 'test.pdf'));
+        $this->assertEquals('..test.pdf', $ref->invoke($connection, '../test.pdf'));
+        $this->assertEquals('test.pdf', $ref->invoke($connection, "test\x00.pdf"));
+        $this->assertEquals('upload', $ref->invoke($connection, ''));
+        $this->assertEquals('upload', $ref->invoke($connection, '///'));
+    }
+
+    public function test_container_upload_rejects_malformed_array()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $connection = new FileMakerConnection('filemaker', 'tester', '', [
+            'name' => 'filemaker',
+            'host' => 'filemaker.test',
+            'database' => 'tester',
+            'username' => 'test',
+            'password' => 'test',
+            'protocol' => 'https',
+            'cache_session_token' => false,
+        ]);
+
+        $query = $connection->query();
+        $query->from = 'pets';
+        $query->recordId(1);
+        $query->containerFieldName = 'photo';
+        $query->containerFile = ['not-a-file', 123]; // bad payload
+
+        $connection->uploadToContainerField($query);
+    }
+
     protected function overrideDBHost()
     {
         Config::set('database.connections.filemaker.host', 'filemaker.test');

--- a/tests/Unit/FileMakerConnectionTest.php
+++ b/tests/Unit/FileMakerConnectionTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Unit;
 
+use GearboxSolutions\EloquentFileMaker\Database\Query\FMBaseBuilder;
 use GearboxSolutions\EloquentFileMaker\Services\FileMakerConnection;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
 use Mockery;
 use Tests\TestCase;
 
@@ -126,6 +128,46 @@ class FileMakerConnectionTest extends TestCase
 
         $combined = implode(' ', $loggedSql);
         $this->assertStringNotContainsString('dapitester', $combined, 'Raw credentials should not appear in query log');
+    }
+
+    public function test_layout_name_is_encoded_in_url()
+    {
+        $connection = $this->connection();
+        $connection->setLayout('my layout');
+
+        // Use reflection to call the protected getLayoutUrl
+        $ref = new \ReflectionMethod($connection, 'getLayoutUrl');
+        $url = $ref->invoke($connection);
+
+        $this->assertStringContainsString('/layouts/my%20layout', $url);
+        $this->assertStringNotContainsString('/layouts/my layout', $url);
+    }
+
+    public function test_database_name_is_encoded_in_url()
+    {
+        Config::set('database.connections.filemaker.database', 'my database');
+        $connection = $this->connection();
+
+        $ref = new \ReflectionMethod($connection, 'getDatabaseUrl');
+        $url = $ref->invoke($connection);
+
+        $this->assertStringContainsString('/databases/my%20database', $url);
+    }
+
+    public function test_invalid_record_id_is_rejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder = new FMBaseBuilder($this->connection());
+        $builder->recordId('abc/../../hack');
+    }
+
+    public function test_numeric_record_id_is_accepted()
+    {
+        $builder = new FMBaseBuilder($this->connection());
+        $builder->recordId(42);
+
+        $this->assertEquals(42, $builder->getRecordId());
     }
 
     protected function overrideDBHost()


### PR DESCRIPTION
We use this package and we wanted to contribute a small security tightening pass that should benefit other users as well.

This PR focuses on reducing accidental exposure and hardening a few request-building paths without changing the
package’s overall shape.

- redact FileMaker login credentials before they reach query log events
- encode dynamic Data API path segments and validate record IDs earlier
- add TLS config options for self-signed HTTPS setups
- keep the Laravel 10 HTTP client fallback in place where needed
- add optional query-log redaction for request payloads
- reduce exception detail outside debug mode
- sanitize container upload filenames and reject malformed upload payloads
- replace forever-cached session tokens with a bounded TTL
- scope guardable-column cache keys by connection to avoid collisions across shared layout names
- add test coverage around the affected paths

Compatibility notes :

- plain HTTP is still supported here, but it is treated as explicitly insecure
- this branch currently bumps the PHP floor to 8.2 because of the SensitiveParameter additions and PHP's EOL.