### PR TITLE
FieldMetaData is nested under response

### DIFF
--- a/src/Database/Schema/FMBuilder.php
+++ b/src/Database/Schema/FMBuilder.php
@@ -13,7 +13,7 @@ class FMBuilder extends \Illuminate\Database\Schema\Builder
     public function getColumnListing($table)
     {
         $layoutMetaData = $this->connection->getLayoutMetadata($table);
-        $fieldMetaData = $layoutMetaData['fieldMetaData'];
+        $fieldMetaData = $layoutMetaData['response']['fieldMetaData'];
         $columns = array_column($fieldMetaData, 'name');
 
         return $columns;


### PR DESCRIPTION
The getlayoutMetadata returns an associative array with response and messages keys and the fieldMetaData key is nested under the response key.